### PR TITLE
Clarify external PSK is optional in 8446 vs. required in this extension

### DIFF
--- a/draft-ietf-tls-8773bis.xml
+++ b/draft-ietf-tls-8773bis.xml
@@ -552,8 +552,8 @@
         addition of this extension does not introduce any security defects.  This
         extension requires the use of certificates for authentication, but the
         processing of certificates is unchanged by this extension.  This extension
-        places an external PSK in the key schedule as part of the computation of the
-        Early Secret.  In the initial handshake without this extension, the
+        requires an external PSK in the key schedule as part of the computation of the
+        Early Secret.  In the initial handshake without external PSK in <xref target="RFC8446" format="default"/>, the
         Early Secret is computed as:
       </t>
 


### PR DESCRIPTION
To address the concern mentioned https://github.com/tlswg/rfc8773bis/pull/2#issuecomment-2910123198

Detailed description in https://github.com/tlswg/rfc8773bis/pull/2#issuecomment-2914168965