### PR TITLE
Perhaps a typo?

### DIFF
--- a/draft-ietf-tls-8773bis.xml
+++ b/draft-ietf-tls-8773bis.xml
@@ -510,7 +510,7 @@
         processing of certificates is unchanged by this extension.  This
         extension requires an external PSK in the key schedule as part of
         the computation of the Early Secret.  In the initial handshake
-        without this an external PSK in <xref target="RFC8446" format="default"/>,
+        without an external PSK in <xref target="RFC8446" format="default"/>,
         the Early Secret is computed as:
       </t>
 <sourcecode>


### PR DESCRIPTION
Maybe someone changed it by mistake, but the new sentence structure does not make sense to me. 

Reverting it back to what I proposed here:
https://github.com/tlswg/rfc8773bis/pull/4/files